### PR TITLE
Added `post-create.sh` script & 'dpcmcserver' volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y git \
     wget
 
 # Create directories
-RUN mkdir /dpcmcserver-build /dpcmcserver /dpcmcserver/plugins
+RUN mkdir /dpcmcserver-build
 
 # Build server
 WORKDIR /dpcmcserver-build
@@ -16,11 +16,8 @@ RUN wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastS
 RUN git config --global --unset core.autocrlf || :
 RUN java -jar BuildTools.jar --rev 1.20.4
 
-# Copy server JAR
-RUN cp ./spigot-1.20.4.jar /dpcmcserver/spigot-1.20.4.jar
-
 # Download & install community plugins -----------------------------
-WORKDIR /dpcmcserver/plugins
+WORKDIR /jars
 RUN wget https://github.com/Dans-Plugins/Activity-Tracker/releases/download/1.2.0/ActivityTracker-1.2.0.jar
 RUN wget https://github.com/Dans-Plugins/AlternateAccountFinder/releases/download/2.0.0/AlternateAccountFinder-2.0.0-all.jar
 # TODO: conquest recipes?
@@ -47,11 +44,10 @@ RUN wget https://github.com/Dans-Plugins/SimpleSkills/releases/download/2.1.0/Si
 RUN wget https://github.com/Dans-Plugins/Wild-Pets/releases/download/1.5.1/WildPets-1.5.1.jar
 # --------------------------------------------------------
 
-# Accept EULA
-WORKDIR /dpcmcserver
-RUN echo "eula=true" > ./eula.txt
+# Copy post-create.sh
+COPY ./post-create.sh /post-create.sh
 
 # Run server
+WORKDIR /dpcmcserver
 EXPOSE 25565
-EXPOSE 8123
-ENTRYPOINT java -jar ./spigot-1.20.4.jar
+ENTRYPOINT /post-create.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu
 
+USER root
+
 # Install dependencies
 RUN apt-get update
 RUN apt-get install -y git \
@@ -46,6 +48,7 @@ RUN wget https://github.com/Dans-Plugins/Wild-Pets/releases/download/1.5.1/WildP
 
 # Copy post-create.sh
 COPY ./post-create.sh /post-create.sh
+RUN chmod +x /post-create.sh
 
 # Run server
 WORKDIR /dpcmcserver

--- a/Dockerfile.dynmap
+++ b/Dockerfile.dynmap
@@ -1,5 +1,7 @@
 FROM ubuntu
 
+USER root
+
 # Install dependencies
 RUN apt-get update
 RUN apt-get install -y git \
@@ -54,6 +56,7 @@ RUN cp /dynmap-build/dynmap/target/Dynmap-*.jar /jars
 
 # Copy post-create.sh
 COPY ./post-create.sh /post-create.sh
+RUN chmod +x /post-create.sh
 
 # Run server
 WORKDIR /dpcmcserver

--- a/Dockerfile.dynmap
+++ b/Dockerfile.dynmap
@@ -8,7 +8,7 @@ RUN apt-get install -y git \
     wget
 
 # Create directories
-RUN mkdir /dynmap-build /dpcmcserver-build /dpcmcserver /dpcmcserver/plugins
+RUN mkdir /dynmap-build /dpcmcserver-build
 
 # Clone & build dynmap (placed here to take advantage of docker caching)
 RUN git clone https://github.com/webbukkit/dynmap /dynmap-build/dynmap
@@ -21,11 +21,8 @@ RUN wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastS
 RUN git config --global --unset core.autocrlf || :
 RUN java -jar BuildTools.jar --rev 1.20.4
 
-# Copy server files
-RUN cp /dpcmcserver-build/spigot-1.20.4.jar /dpcmcserver/spigot-1.20.4.jar
-
 # Download & install community plugins -----------------------------
-WORKDIR /dpcmcserver/plugins
+WORKDIR /jars
 RUN wget https://github.com/Dans-Plugins/Activity-Tracker/releases/download/1.2.0/ActivityTracker-1.2.0.jar
 RUN wget https://github.com/Dans-Plugins/AlternateAccountFinder/releases/download/2.0.0/AlternateAccountFinder-2.0.0-all.jar
 # TODO: conquest recipes?
@@ -52,14 +49,14 @@ RUN wget https://github.com/Dans-Plugins/SimpleSkills/releases/download/2.1.0/Si
 RUN wget https://github.com/Dans-Plugins/Wild-Pets/releases/download/1.5.1/WildPets-1.5.1.jar
 # --------------------------------------------------------
 
-# Install Dynmap
-RUN cp /dynmap-build/dynmap/target/Dynmap-*.jar /dpcmcserver/plugins
+# Move Dynmap JAR
+RUN cp /dynmap-build/dynmap/target/Dynmap-*.jar /jars
 
-# Accept EULA
-WORKDIR /dpcmcserver
-RUN echo "eula=true" > eula.txt
+# Copy post-create.sh
+COPY ./post-create.sh /post-create.sh
 
 # Run server
+WORKDIR /dpcmcserver
 EXPOSE 25565
 EXPOSE 8123
-ENTRYPOINT java -jar /dpcmcserver/spigot-1.20.4.jar
+ENTRYPOINT /post-create.sh

--- a/compose.yml
+++ b/compose.yml
@@ -5,12 +5,9 @@ services:
     container_name: dpc-mc-server
     ports:
       - "25565:25565"
-    restart: always
+    restart: unless-stopped
     volumes:
-      - world:/dpcmcserver/world
-      - world_nether:/dpcmcserver/world_nether
-      - world_the_end:/dpcmcserver/world_the_end
+      - dpcmcserver:/dpcmcserver
+
 volumes:
-  world:
-  world_nether:
-  world_the_end:
+  dpcmcserver:

--- a/post-create.sh
+++ b/post-create.sh
@@ -1,0 +1,19 @@
+echo "Running 'post-create.sh' script..."
+if [ -z "$(ls -A /dpcmcserver)" ]; then
+    echo "Setting up server..."
+    # Copy server JAR
+    cp /dpcmcserver-build/spigot-1.20.4.jar /dpcmcserver/spigot-1.20.4.jar
+
+    # Create plugins directory
+    mkdir /dpcmcserver/plugins
+
+    # Copy JARs
+    cp /jars/*.jar /dpcmcserver/plugins
+
+    # Accept EULA
+    cd /dpcmcserver && echo "eula=true" > eula.txt
+else
+    echo "Server is already set up."
+fi
+
+java -jar /dpcmcserver/spigot-1.20.4.jar


### PR DESCRIPTION
## Problem
The minecraft server files need to be persisted in such a way that they are not overwritten every time the docker image is built.

## Solution
The /dpcmcserver directory is now a docker volume, and any interaction with it takes place after image build. This means server administrators will need to manually update plugins.

## Testing
This was tested using `docker compose` locally.