### PR TITLE
Added `deposit-box` directory mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-volume-mounts
+deposit-box

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,12 @@ services:
       - "25565:25565"
     restart: unless-stopped
     volumes:
-      - dpcmcserver:/dpcmcserver
+      - type: volume
+        source: dpcmcserver
+        target: /dpcmcserver
+      - type: bind
+        source: ./deposit-box
+        target: /deposit-box
 
 volumes:
   dpcmcserver:


### PR DESCRIPTION
## Problem
There is a need to transfer files from the host system to the container running the minecraft server.

## Solution
A `deposit-box` bind mount has been added.

## Testing
This was run locally with docker compose.