### PR TITLE
ViaVersion & ViaBackwards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ RUN wget https://github.com/Dans-Plugins/SimpleSkills/releases/download/2.1.0/Si
 RUN wget https://github.com/Dans-Plugins/Wild-Pets/releases/download/1.5.1/WildPets-1.5.1.jar
 # --------------------------------------------------------
 
+# Download and install other plugins -----------------------------
+RUN wget https://github.com/ViaVersion/ViaVersion/releases/download/4.9.2/ViaVersion-4.9.2.jar
+RUN wget https://github.com/ViaVersion/ViaBackwards/releases/download/4.9.1/ViaBackwards-4.9.1.jar
+# --------------------------------------------------------
+
 # Copy post-create.sh
 COPY ./post-create.sh /post-create.sh
 RUN chmod +x /post-create.sh

--- a/Dockerfile.dynmap
+++ b/Dockerfile.dynmap
@@ -51,6 +51,11 @@ RUN wget https://github.com/Dans-Plugins/SimpleSkills/releases/download/2.1.0/Si
 RUN wget https://github.com/Dans-Plugins/Wild-Pets/releases/download/1.5.1/WildPets-1.5.1.jar
 # --------------------------------------------------------
 
+# Download and install other plugins -----------------------------
+RUN wget https://github.com/ViaVersion/ViaVersion/releases/download/4.9.2/ViaVersion-4.9.2.jar
+RUN wget https://github.com/ViaVersion/ViaBackwards/releases/download/4.9.1/ViaBackwards-4.9.1.jar
+# --------------------------------------------------------
+
 # Move Dynmap JAR
 RUN cp /dynmap-build/dynmap/target/Dynmap-*.jar /jars
 


### PR DESCRIPTION
## Problem
It can be inconvenient to switch minecraft versions just to join a particular server.

## Solution
ViaVersion & ViaBackwards will now be installed to allow almost any client version to connect to the server.

## Testing
The server was run locally w/ docker compose & I was able to join using a 1.19.4 client.