### PR TITLE
Overrode default ops by providing ops.json config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN wget https://github.com/ViaVersion/ViaBackwards/releases/download/4.9.1/ViaB
 COPY ./post-create.sh /post-create.sh
 RUN chmod +x /post-create.sh
 
+# Copy config directory
+COPY ./config /config
+
 # Run server
 WORKDIR /dpcmcserver
 EXPOSE 25565

--- a/config/ops.json
+++ b/config/ops.json
@@ -1,0 +1,8 @@
+[
+  {
+    "uuid": "0a9fa342-3139-49d7-8acb-fcf4d9c1f0ef",
+    "name": "DanTheTechMan",
+    "level": 4,
+    "bypassesPlayerLimit": false
+  }
+]

--- a/post-create.sh
+++ b/post-create.sh
@@ -10,6 +10,9 @@ if [ -z "$(ls -A /dpcmcserver)" ]; then
     # Copy JARs
     cp /jars/*.jar /dpcmcserver/plugins
 
+    # Copy config files
+    cp /config/ops.json /dpcmcserver
+
     # Accept EULA
     cd /dpcmcserver && echo "eula=true" > eula.txt
 else

--- a/up.bat
+++ b/up.bat
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker-compose up -d --build

--- a/up.sh
+++ b/up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker-compose up -d --build


### PR DESCRIPTION
## Problem
When running with Docker, there is no clear way to execute console commands, so op cannot be granted for testing purposes.

## Solution
An `ops.json` file is provided to override the default operators and allow for full local testing.

## Testing
This was tested locally with docker compose. I was able to enter creative mode immediately.

## Relevant Issue
closes #9 