### PR TITLE
Plugin Overrides

### DIFF
--- a/Dockerfile.dynmap
+++ b/Dockerfile.dynmap
@@ -63,6 +63,9 @@ RUN cp /dynmap-build/dynmap/target/Dynmap-*.jar /jars
 COPY ./post-create.sh /post-create.sh
 RUN chmod +x /post-create.sh
 
+# Copy config directory
+COPY ./config /config
+
 # Run server
 WORKDIR /dpcmcserver
 EXPOSE 25565

--- a/post-create.sh
+++ b/post-create.sh
@@ -19,4 +19,7 @@ else
     echo "Server is already set up."
 fi
 
+echo "Copying file overrides..."
+cp /deposit-box/plugin-overrides/*.jar /dpcmcserver/plugins
+
 java -jar /dpcmcserver/spigot-1.20.4.jar


### PR DESCRIPTION
## Problem
At this time, overriding a plugin JAR involves exec'ing into the machine and manually copying the JAR from the deposit-box to the /dpcmcserver/plugins directory.

## Solution
A subdirectory of the deposit-box called 'plugin-overrides' has been added. The `post-create.sh` script will copy any JARs in this directory to the /dpcmcserver/plugins directory each time the container is run. Developers will still need to delete the old JAR, but this can be addressed later.