### PR TITLE
Correct documentation drift found in an accuracy sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the `MINECRAFT_VERSION` description in `CONFIG.md`, which stated that the value is used by BuildTools. BuildTools uses the hardcoded `--rev` argument in the `Dockerfile`; `MINECRAFT_VERSION` only names the Spigot JAR that the entrypoint copies and launches at runtime. The requirement to change both together is now documented.
+- Corrected the instructions for enabling or disabling a plugin and for resetting the server in `USER_GUIDE.md`, which told users to apply `.env` changes with `docker compose restart`. That command does not recreate the container, so the edited values never reach it; `./up.sh` is required.
+
+### Changed
+
+- Documented in `USER_GUIDE.md` that the `deposit-box/` directory is a staging area only, with no automatic installation, and described how a deposited JAR interacts with the bundled plugin toggles.
+- Added an "Apply a change made to `.env`" entry to `COMMANDS.md` and noted the limitation of `docker compose restart` on the restart entry.
+- Listed the bundled third-party plugins in `COMMANDS.md` so that its plugin list matches `README.md` and `CONFIG.md`.
+- Noted in `README.md` and `CONFIG.md` that not every bundled plugin is enabled by default and that toggle changes require recreating the container.
+
 ## [1.0.0] – 2024-01-01
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -23,7 +23,7 @@ The management commands below are used to operate the server from the host machi
 
 ### Apply a change made to `.env`
 
-**Description:** Recreate the container so that edited environment variables (plugin toggles, `OPERATOR_*`, `OVERWRITE_EXISTING_SERVER`, `MINECRAFT_VERSION`) take effect.  
+**Description:** Recreate the container so that edited environment variables (plugin toggles, `OPERATOR_*`, `OVERWRITE_EXISTING_SERVER`, `MINECRAFT_VERSION`) take effect. This is the same command used to start the server; Compose recreates a container whose environment has changed. `docker compose up -d` is equivalent when the image does not also need rebuilding.  
 **Usage:** `./up.sh`
 
 ### View server logs

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -18,8 +18,13 @@ The management commands below are used to operate the server from the host machi
 
 ### Restart the server
 
-**Description:** Restart the running container without rebuilding the image.  
+**Description:** Restart the running container without recreating it. Changes made to `.env` are **not** applied by this command, because the container's environment is fixed when the container is created; use `./up.sh` to apply those.  
 **Usage:** `docker compose restart`
+
+### Apply a change made to `.env`
+
+**Description:** Recreate the container so that edited environment variables (plugin toggles, `OPERATOR_*`, `OVERWRITE_EXISTING_SERVER`, `MINECRAFT_VERSION`) take effect.  
+**Usage:** `./up.sh`
 
 ### View server logs
 
@@ -38,7 +43,9 @@ The management commands below are used to operate the server from the host machi
 
 ## Plugin Commands
 
-Each installed plugin provides its own set of in-game commands. Links to their individual command references are listed below:
+Each installed plugin provides its own set of in-game commands. Links to their individual command references are listed below. Whether a given plugin is installed depends on its toggle in `.env`; see [CONFIG.md](CONFIG.md).
+
+### DPC Plugins
 
 - [ActivityTracker](https://github.com/Dans-Plugins/ActivityTracker)
 - [AlternateAccountFinder](https://github.com/Dans-Plugins/AlternateAccountFinder)
@@ -58,3 +65,11 @@ Each installed plugin provides its own set of in-game commands. Links to their i
 - [PlayerLore](https://github.com/Dans-Plugins/PlayerLore)
 - [SimpleSkills](https://github.com/Dans-Plugins/SimpleSkills)
 - [WildPets](https://github.com/Dans-Plugins/WildPets)
+
+### Third-Party Plugins
+
+- [BlueMap](https://bluemap.bluecolored.de/)
+- [Dynmap](https://www.spigotmc.org/resources/dynmap.274/)
+- [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/)
+- [ViaBackwards](https://www.spigotmc.org/resources/viabackwards.27448/)
+- [ViaVersion](https://www.spigotmc.org/resources/viaversion.19254/)

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -6,7 +6,9 @@ All configuration is done through environment variables. Copy `sample.env` to `.
 
 **Type:** string  
 **Default:** `1.21.4`  
-**Description:** The version of Minecraft (and Spigot) that the server runs. This value is used by BuildTools inside the Docker image and must match a valid Spigot release.
+**Description:** Names the Spigot JAR that the container copies into the server directory and launches at startup (`spigot-<MINECRAFT_VERSION>.jar`). The value is read at runtime by `resources/post-create.sh`; it is **not** read by BuildTools. The Spigot revision that is compiled into the image is set separately, by the hardcoded `--rev` argument in the `Dockerfile`.
+
+**Changing the Minecraft version therefore requires editing two places:** this variable *and* the `--rev` argument in the `Dockerfile`. If the two disagree, the image still builds successfully and the container then exits at startup, because the JAR it has been told to launch was never produced.
 
 **Example:**
 
@@ -56,6 +58,8 @@ OPERATOR_LEVEL=4
 **Default:** `false`  
 **Description:** When `true`, all existing server data is deleted and the server is re-initialised on the next container start. **Use with caution** – this is destructive. Reset to `false` immediately after the reset to avoid accidental data loss.
 
+Note that the value is captured in the container's environment when the container is created. Setting it back to `false` and then running `docker compose restart` does **not** clear it: the old value is still in the running container's environment, and the server data is wiped again on every restart. The container must be recreated with `./up.sh` for the new value to take effect.
+
 **Example:**
 
 ```env
@@ -66,7 +70,7 @@ OVERWRITE_EXISTING_SERVER=false
 
 ## DPC Plugin Toggles
 
-Each of the following variables accepts `true` (install and enable the plugin) or `false` (do not install it). Set them in `.env` before starting the server.
+Each of the following variables accepts `true` (install and enable the plugin) or `false` (do not install it). Set them in `.env` before starting the server. Because the toggles are read from the container's environment by the entrypoint script, an edit made after the container already exists only takes effect once the container has been recreated with `./up.sh` – see [Enabling or Disabling a Plugin](USER_GUIDE.md#enabling-or-disabling-a-plugin).
 
 | Variable | Default | Plugin |
 |----------|---------|--------|

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The server ships with the following DPC plugins (each can be toggled on or off v
 - [SimpleSkills](https://github.com/Dans-Plugins/SimpleSkills)
 - [WildPets](https://github.com/Dans-Plugins/WildPets)
 
-Third-party plugins are bundled alongside them and are toggled the same way: [BlueMap](https://bluemap.bluecolored.de/) (off by default), [Dynmap](https://www.spigotmc.org/resources/dynmap.274/), [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/), [ViaBackwards](https://www.spigotmc.org/resources/viabackwards.27448/), and [ViaVersion](https://www.spigotmc.org/resources/viaversion.19254/).
+Third-party plugins are bundled alongside them and are toggled the same way: [BlueMap](https://bluemap.bluecolored.de/), [Dynmap](https://www.spigotmc.org/resources/dynmap.274/), [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/), [ViaBackwards](https://www.spigotmc.org/resources/viabackwards.27448/), and [ViaVersion](https://www.spigotmc.org/resources/viaversion.19254/).
 
 Not every bundled plugin is enabled by default. See the [Configuration Guide](CONFIG.md) for each toggle's default value, and note that a toggle changed after the container already exists only takes effect once the container has been recreated with `./up.sh`.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ The server ships with the following DPC plugins (each can be toggled on or off v
 - [SimpleSkills](https://github.com/Dans-Plugins/SimpleSkills)
 - [WildPets](https://github.com/Dans-Plugins/WildPets)
 
-Third-party plugins also included: Dynmap, BlueMap, PlaceholderAPI, ViaVersion, ViaBackwards.
+Third-party plugins are bundled alongside them and are toggled the same way: [BlueMap](https://bluemap.bluecolored.de/) (off by default), [Dynmap](https://www.spigotmc.org/resources/dynmap.274/), [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/), [ViaBackwards](https://www.spigotmc.org/resources/viabackwards.27448/), and [ViaVersion](https://www.spigotmc.org/resources/viaversion.19254/).
+
+Not every bundled plugin is enabled by default. See the [Configuration Guide](CONFIG.md) for each toggle's default value, and note that a toggle changed after the container already exists only takes effect once the container has been recreated with `./up.sh`.
 
 ## Usage
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -39,6 +39,8 @@
 docker compose restart
 ```
 
+This restarts the existing container without recreating it, which is what you want after editing files inside the container. It does **not** pick up changes made to `.env`, because environment variables are captured when the container is created. To apply an `.env` change, recreate the container with `./up.sh` instead.
+
 ### Viewing Server Logs
 
 ```
@@ -60,15 +62,30 @@ docker exec -it dpc-mc-server /bin/bash
 
 ### Adding Plugins to the Deposit Box
 
-Place plugin JARs or override configuration files in the `deposit-box/` directory before starting the server. The container mounts this directory so that its contents are available at `/deposit-box` inside the container.
+Place plugin JARs or override configuration files in the `deposit-box/` directory before starting the server. The container bind-mounts this directory so that its contents are available at `/deposit-box` inside the container.
+
+Nothing is installed automatically from the deposit box: the directory is a staging area only. To install a JAR that has been placed there, open a shell in the container and copy it across yourself, then restart:
+
+```
+docker exec -it dpc-mc-server /bin/bash
+cp /deposit-box/YourPlugin.jar /dpcmcserver/plugins/
+exit
+docker compose restart
+```
+
+Be aware that the entrypoint script re-applies every bundled plugin toggle on each start. A JAR whose filename begins with the same prefix as a bundled plugin (for example `WildPets-`) is therefore affected by that plugin's toggle: with the toggle set to `true` the bundled copy is placed alongside it and both versions are loaded, and with the toggle set to `false` the deposited copy is deleted along with the bundled one.
 
 ### Enabling or Disabling a Plugin
 
-Edit `.env` and set the corresponding `<PLUGIN>_ENABLED` variable to `true` or `false`, then restart the server with `docker compose restart`. See [CONFIG.md](CONFIG.md) for the full list of plugin toggles.
+Edit `.env` and set the corresponding `<PLUGIN>_ENABLED` variable to `true` or `false`, then recreate the container with `./up.sh`. See [CONFIG.md](CONFIG.md) for the full list of plugin toggles.
+
+`docker compose restart` is not sufficient here. The toggles reach the entrypoint script through the container's environment, which is fixed when the container is created, so a restarted container still sees the old values.
 
 ### Resetting the Server
 
-Set `OVERWRITE_EXISTING_SERVER=true` in `.env` and restart. **This deletes all existing server data.** Reset the variable to `false` after the restart to prevent accidental data loss.
+Set `OVERWRITE_EXISTING_SERVER=true` in `.env` and run `./up.sh`. **This deletes all existing server data.** Set the variable back to `false` afterwards and run `./up.sh` again to prevent accidental data loss.
+
+Both steps require `./up.sh` rather than `docker compose restart`, for the reason given under [Restarting the Server](#restarting-the-server). Clearing the variable in `.env` and then merely restarting leaves `OVERWRITE_EXISTING_SERVER=true` in the running container's environment, which wipes the server data again on every subsequent restart.
 
 ## Permissions
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -73,7 +73,7 @@ exit
 docker compose restart
 ```
 
-Be aware that the entrypoint script re-applies every bundled plugin toggle on each start. A JAR whose filename begins with the same prefix as a bundled plugin (for example `WildPets-`) is therefore affected by that plugin's toggle: with the toggle set to `true` the bundled copy is placed alongside it and both versions are loaded, and with the toggle set to `false` the deposited copy is deleted along with the bundled one.
+Be aware that the entrypoint script re-applies every bundled plugin toggle on each start. A JAR whose filename begins with the same prefix as a bundled plugin (for example `WildPets-`) is therefore affected by that plugin's toggle: with the toggle set to `true` the bundled copy is placed alongside it, leaving two JARs that provide the same plugin, which Spigot will not load cleanly; and with the toggle set to `false` the deposited copy is deleted along with the bundled one, because the removal matches on the same prefix. Deposit a newer version of a bundled plugin by replacing the bundled JAR in `resources/jars/` and rebuilding, not through the deposit box.
 
 ### Enabling or Disabling a Plugin
 


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

A documentation accuracy sweep was run across `README.md`, `USER_GUIDE.md`, `COMMANDS.md`, `CONFIG.md`, `CONTRIBUTING.md`, and `sample.env`, checking every claim against the file, command, or environment variable it describes. Three claims were found to contradict the configuration, and are corrected here. No configuration file is modified by this PR — where the defect is in the configuration rather than in the prose, an issue has been filed instead.

**`CONFIG.md` — `MINECRAFT_VERSION` was described as being used by BuildTools.** It is not. BuildTools is driven by the hardcoded `--rev 1.21.4` argument in the `Dockerfile`; `MINECRAFT_VERSION` reaches the container through `compose.yml` and is read at runtime by `resources/post-create.sh`, where it only names the Spigot JAR that is copied and launched. Changing the variable alone produces a green build followed by a container that exits because the JAR it was told to launch does not exist. The description now says what the value actually does, and states that both places must be changed together.

**`USER_GUIDE.md` — `.env` changes were said to be applied with `docker compose restart`.** That command restarts the existing container without recreating it, so the container's environment — fixed at creation time — still holds the old values. The instructions for enabling or disabling a plugin, and for resetting the server, now point at `./up.sh`. The reset case is the sharper one: clearing `OVERWRITE_EXISTING_SERVER` in `.env` and then merely restarting leaves `OVERWRITE_EXISTING_SERVER=true` live in the container, which wipes the server data again on every subsequent restart. That trap is now called out in both `USER_GUIDE.md` and `CONFIG.md`.

**`USER_GUIDE.md` — the deposit box was described in a way that implies installation.** Nothing in the repository reads `/deposit-box`; `compose.yml` bind-mounts it and no other file refers to it. It is now described as a staging area, with the manual copy step spelled out, along with how a deposited JAR interacts with a bundled plugin's toggle (the `false` branch of `manage_plugin_dependencies` deletes by prefix glob, so a deposited `WildPets-*.jar` is removed along with the bundled one).

Two smaller consistency fixes are included:

- `COMMANDS.md` listed only the eighteen DPC plugins, while `README.md` and `CONFIG.md` also cover the five bundled third-party plugins. The third-party list has been added so that all three plugin lists match.
- `README.md` stated that third-party plugins are "also included" without noting that they are toggled the same way and that BlueMap is off by default.

An "Apply a change made to `.env`" entry has been added to `COMMANDS.md`, and all of the above is recorded under `## [Unreleased]` in `CHANGELOG.md`.

## Issues filed rather than fixed here

Per the documentation-sweep convention, defects located in the configuration rather than in the prose were filed rather than changed under a docs-only PR:

- `BLUEMAP_ENABLED` has no working "off" path — the call to `manage_plugin_dependencies` is wrapped in an `if [ "$BLUEMAP_ENABLED" = "true" ]` guard, so the function's `false` and invalid-value branches are unreachable for that plugin.
- `manage_plugin_dependencies` calls a bare `exit` on an invalid toggle value, which returns `0`, so a typo in `.env` stops the container in a way that is indistinguishable from a clean shutdown.
- The shell-form `ENTRYPOINT` combined with a non-`exec` `java` invocation prevents `SIGTERM` from reaching Spigot, so `./down.sh` and `docker stop` kill the server rather than letting it save.
- `MINECRAFT_VERSION` and the `Dockerfile` `--rev` argument duplicate the same value with nothing enforcing their agreement.
- `CONTRIBUTING.md` and `.github/copilot-instructions.md` both instruct contributors to branch from and target `develop`, which does not exist on the remote.
- `up.sh` and `down.sh` invoke the Compose v1 `docker-compose` binary while every document specifies the v2 `docker compose` plugin, and neither script carries a shebang.

## Issues not selected for this cycle

The three issues that were open at triage time were all deferred, and the reason is recorded here rather than as comments on each:

- **#4 (Postgres Server for Medieval Factions)** and **#6 (Vantage Server Panel)** — both require a new PostgreSQL service in `compose.yml`, and #6 additionally requires integrating an external project. They overlap and should be designed together; neither fits a documentation cycle. The stale draft PR #27 that attempted #4 has been closed as conflicting, with the gaps in its approach recorded on it.
- **#21 (Use `plugin-overrides` directory or remove it)** — the decision between using the directory and removing it is a maintainer's call, not a documentation fix. Findings have been added as a comment on that issue.

## Test plan

- [x] Wiring parity (`sample.env` ↔ `compose.yml` ↔ `resources/post-create.sh` ↔ `resources/jars/` ↔ `Dockerfile` `--rev`) — `PARITY: PASS` on this branch, and unchanged from `main`, since no configuration file is touched.
- [x] Every documented default in `CONFIG.md` compared mechanically against `sample.env` — 28 variables checked, no mismatches, none missing in either direction.
- [x] Every claim rewritten in this PR re-read against its source file at `d42e0ec` before being written.
- [x] All internal document links and anchors in the changed sections resolved by hand.
- [ ] `docker build` — **not run.** Docker is unavailable in the environment this PR was prepared in, as are `bash -n` and `shellcheck`. The gap is recorded as **UNVERIFIED-not-applicable**: this PR modifies only Markdown, so no file within the `Build` workflow's scope is changed, and the workflow's result on this head commit stands as the anchor.
- [ ] No JAR under `resources/jars/` was added, removed, or replaced, so no binary provenance applies.

## Tracking

No tracking issue — the drift was found during a documentation accuracy sweep rather than reported. No `Closes` reference is therefore included.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_
